### PR TITLE
fixes for autogen parse code failing to compile, added end-to-end tests

### DIFF
--- a/xdrgen/src/lib.rs
+++ b/xdrgen/src/lib.rs
@@ -107,19 +107,23 @@ pub fn generate<In, Out>(infile: &str, mut input: In, mut output: Out) -> Result
             })
             .map(|c| c.define(&xdr, e));
 
-        let typedefs = xdr.typedefs()
-            .map(|(n, ty)| spec::Typedef(n.clone(), ty.clone()))
+        let typespecs = xdr.typespecs()
+            .map(|(n, ty)| spec::Typespec(n.clone(), ty.clone()))
             .map(|c| c.define(&xdr, e));
 
-        let packers = xdr.typedefs()
-            .map(|(n, ty)| spec::Typedef(n.clone(), ty.clone()))
+        let typesyns = xdr.typesyns()
+            .map(|(n, ty)| spec::Typesyn(n.clone(), ty.clone()))
+            .map(|c| c.define(&xdr, e));
+
+        let packers = xdr.typespecs()
+            .map(|(n, ty)| spec::Typespec(n.clone(), ty.clone()))
             .filter_map(|c| result_option(c.pack(&xdr, e)));
         
-        let unpackers = xdr.typedefs()
-            .map(|(n, ty)| spec::Typedef(n.clone(), ty.clone()))
+        let unpackers = xdr.typespecs()
+            .map(|(n, ty)| spec::Typespec(n.clone(), ty.clone()))
             .filter_map(|c| result_option(c.unpack(&xdr, e)));
 
-        let module: Vec<_> = try!(fold_result(consts.chain(typedefs).chain(packers).chain(unpackers)));
+        let module: Vec<_> = try!(fold_result(consts.chain(typespecs).chain(typesyns).chain(packers).chain(unpackers)));
 
         let _ = writeln!(output, r#"
 // GENERATED CODE

--- a/xdrgen/src/spec/test.rs
+++ b/xdrgen/src/spec/test.rs
@@ -204,3 +204,32 @@ fn constants() {
         assert!(g.is_ok());
     }
 }
+
+#[test]
+fn union_default() {
+    let s = grammar::specification(r#"
+union foo switch (int x) {
+case 0:
+    int val;
+default:
+    void;
+};
+"#);
+    println!("spec {:?}", s);
+    assert!(s.is_ok())
+}
+
+#[test]
+fn union_default_nonempty() {
+    let s = grammar::specification(r#"
+union foo switch (int x) {
+case 0:
+    int val;
+default:
+    bool bye;
+};
+"#);
+    println!("spec {:?}", s);
+    assert!(s.is_ok())
+
+}

--- a/xdrgen/src/spec/xdr.rustpeg
+++ b/xdrgen/src/spec/xdr.rustpeg
@@ -136,14 +136,17 @@ union_default -> Decl
 const_def -> Defn
     = const id:identifier eq v:constant semi    { Defn::Const(id, v) }
 
-type_def -> (String, Type)
-    = typedef d:declaration semi               { if let Decl::Named(name, ty) = d { (name, ty) } else { return Failed } }
-    / enum id:identifier e:enum_body semi      { (id, Type::Enum(e)) }
-    / struct id:identifier s:struct_body semi  { (id, Type::Struct(s)) }
-    / union id:identifier u:union_body semi    { (id, Type::union(u)) }
+type_def -> Defn
+    = typedef d:declaration semi               { if let Decl::Named(name, ty) = d {
+                                                    if ty.is_syn() { Defn::Typesyn(name, ty) }
+                                                    else { Defn::Typespec(name, ty) }
+                                                 } else { return Failed } }
+    / enum id:identifier e:enum_body semi      { Defn::Typespec(id, Type::Enum(e)) }
+    / struct id:identifier s:struct_body semi  { Defn::Typespec(id, Type::Struct(s)) }
+    / union id:identifier u:union_body semi    { Defn::Typespec(id, Type::union(u)) }
 
 definition -> Defn
-    = t:type_def        { let (n, t) = t; Defn::Typedef(n, t) }
+    = t:type_def        { t }
     / c:const_def       { c }
 
 #[pub]

--- a/xdrgen/tests/lib.rs
+++ b/xdrgen/tests/lib.rs
@@ -1,0 +1,154 @@
+extern crate xdrgen;
+extern crate xdr_codec;
+
+use std::env;
+use std::fs;
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::io::{Cursor, Write};
+use std::process::Command;
+use std::result;
+
+use xdrgen::{generate, compile};
+use xdr_codec::{Result, Error};
+
+fn verify_gen<P: AsRef<Path>>(xdr_spec: &str,
+                              prog_spec: &str,
+                              outspec: P,
+                              outprog: P,
+                              outexe: P)
+                              -> Result<()> {
+    let fspec = try!(File::create(outspec));
+    try!(generate("", Cursor::new(xdr_spec.as_bytes()), fspec));
+    let mut fprog = try!(File::create(&outprog));
+    try!(fprog.write_all(prog_spec.as_bytes()));
+    
+    let compile = try!(Command::new("rustc")
+                       .arg("-L")
+                       .arg("target/debug/deps")
+                       .arg("-o")
+                       .arg(outexe.as_ref())
+                       .arg(outprog.as_ref())
+                       .output());
+    println!("stdout: {}\n, stderr: {}",
+             String::from_utf8_lossy(&compile.stdout),
+             String::from_utf8_lossy(&compile.stderr));
+    if compile.status.success() {
+        Ok(())        
+    } else {
+        Err(Error::Generic("couldn't compile".to_string()))
+    }
+}
+
+fn verbose_remove<P: AsRef<Path>>(path: P, msg: &str) {
+    if let result::Result::Err(e) = fs::remove_file(path) {
+        println!("{}: {:?}", msg, e);
+    }
+}
+
+// returns specpath, progpath, expath
+fn get_paths(name: &str) -> (PathBuf, PathBuf, PathBuf) {
+    let cdir = env::current_dir().unwrap();
+    let mut specpath = cdir.clone();
+    let mut progpath = cdir.clone();
+    let mut exepath = cdir.clone();
+
+    specpath.push(format!("tests/scratch/{}_xdr.rs", name));
+    progpath.push(format!("tests/scratch/{}.rs", name));
+    exepath.push(format!("tests/scratch/{}", name));
+    (specpath, progpath, exepath)
+}
+
+#[test]
+fn typedef_arrays() {
+    let prog = r#"
+extern crate xdr_codec;
+
+mod typedefs {
+    use xdr_codec;
+
+    #[allow(dead_code)]
+    include!("typedefs_xdr.rs");
+}
+
+fn main() {
+    println!("wheew");
+}
+"#;
+    let spec = r#"
+typedef opaque buf1<20>;
+typedef opaque buf2[10];
+typedef opaque buf3<>;
+"#;
+
+    let (outfile, outprog, outexe) = get_paths("typedefs");
+    let res = verify_gen(spec, prog, &outfile, &outprog, &outexe);
+    verbose_remove(&outfile, "error removing xdr spec");
+    verbose_remove(&outprog, "error removing prog");
+    verbose_remove(&outexe, "error removing exe");
+    assert!(res.is_ok());
+}
+
+#[test]
+fn union_with_default() {
+    let prog = r#"
+extern crate xdr_codec;
+
+mod foo {
+    use xdr_codec;
+
+    #[allow(dead_code)]
+    include!("union_default_xdr.rs");
+}
+
+fn main() {
+    println!("wheew");
+}
+"#;
+    let xdr_spec = r#"
+union foo switch (int bar) {
+case 1:
+    int val;
+default:
+    void;
+};
+"#;
+    let (outfile, outprog, outexe) = get_paths("union_default");
+    let res = verify_gen(xdr_spec, prog, &outfile, &outprog, &outexe);
+    verbose_remove(&outfile, "error removing xdr spec");
+    verbose_remove(&outprog, "error removing prog");
+    verbose_remove(&outexe, "error removing exe");
+    assert!(res.is_ok())
+}
+
+#[test]
+fn union_default_nonempty() {
+    let prog = r#"
+extern crate xdr_codec;
+
+mod foo {
+    use xdr_codec;
+
+    #[allow(dead_code)]
+    include!("union_default_nonempty_xdr.rs");
+}
+
+fn main() {
+    println!("wheew");
+}
+"#;
+    let xdr_spec = r#"
+union foo switch (int bar) {
+case 1:
+    int val;
+default:
+    opaque buf<>;
+};
+"#;
+    let (outfile, outprog, outexe) = get_paths("union_default_nonempty");
+    let res = verify_gen(xdr_spec, prog, &outfile, &outprog, &outexe);
+    verbose_remove(&outfile, "error removing xdr spec");
+    verbose_remove(&outprog, "error removing prog");
+    verbose_remove(&outexe, "error removing exe");
+    assert!(res.is_ok())
+}


### PR DESCRIPTION
including a compilation step to verify autogen code compiles

3 bugs:
 1. typedefs of array types in xdr resulted in more than one trait implementation for the same type (Vec<T> or [T])
 2. rust enum type definitions for unions with default: void arms didn't have a default member
 3. pack code lacked a '&' when pattern matching on the default arm of a union

i'm not sure how my changes interact with the latest commit for array size detection. please advise - are there any tests for this?