### PR TITLE
Pull up byteorder dependency

### DIFF
--- a/xdr-codec/Cargo.toml
+++ b/xdr-codec/Cargo.toml
@@ -14,7 +14,7 @@ include = [ "src/**/*.rs", "tests/**/*.rs", "*.md", "Cargo.toml"  ]
 unstable = []
 
 [dependencies]
-byteorder = "0.5"
+byteorder = "1"
 
 [dev-dependencies]
 quickcheck = "0.2"


### PR DESCRIPTION
Now, that byteorder reached 1.0.0 it may make sense to track stable release