### PR TITLE
Show xdrgen version in -V

### DIFF
--- a/xdrgen/src/xdrgen.rs
+++ b/xdrgen/src/xdrgen.rs
@@ -16,6 +16,7 @@ fn main() {
     let _ = env_logger::init();
 
     let matches = App::new("XDR code generator")
+        .version(env!("CARGO_PKG_VERSION"))
         .arg_from_usage("[FILE] 'Set .x file'")
         .get_matches();
 


### PR DESCRIPTION
```
 $ cargo run xdrgen -- -V
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `/home/plhk/src/rust-xdr/target/debug/xdrgen xdrgen -V`
XDR code generator 0.4.3
```

Useful when xdrgen is installed with `cargo install` to make sure it's latest version