### PR TITLE
Update env_logger to 0.11

### DIFF
--- a/xdrgen/Cargo.toml
+++ b/xdrgen/Cargo.toml
@@ -22,7 +22,7 @@ unstable = []
 
 [dependencies]
 log = "0.3"
-env_logger = "0.4"
+env_logger = "0.11"
 nom = { version="3.1", features=["verbose-errors"] }
 quote = "0.3"
 clap = "2.24"


### PR DESCRIPTION
env_logger 0.4 has a dependency on regex 0.2.11, which is vulnerable to [CVE-2022-24713](https://github.com/advisories/GHSA-m5pq-gvj9-9vr8)